### PR TITLE
Member 도메인 카카오 로그인 기능 추가

### DIFF
--- a/src/main/java/com/sportsecho/common/jwt/JwtUtil.java
+++ b/src/main/java/com/sportsecho/common/jwt/JwtUtil.java
@@ -14,6 +14,7 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
@@ -107,5 +108,10 @@ public class JwtUtil {
 
         //return member email
         return body.getSubject();
+    }
+
+    public void setJwtHeader(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
+        response.setHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER, refreshToken);
     }
 }

--- a/src/main/java/com/sportsecho/member/controller/MemberController.java
+++ b/src/main/java/com/sportsecho/member/controller/MemberController.java
@@ -1,10 +1,11 @@
 package com.sportsecho.member.controller;
 
-import com.sportsecho.common.dto.ApiResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.sportsecho.member.dto.MemberRequestDto;
 import com.sportsecho.member.dto.MemberResponseDto;
 import com.sportsecho.member.entity.MemberDetailsImpl;
 import com.sportsecho.member.service.MemberService;
+import com.sportsecho.member.service.oauth.KakaoService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -14,9 +15,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,10 +27,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final KakaoService kakaoService;
 
     @Autowired
-    public MemberController(@Qualifier("V2") MemberService memberService) {
+    public MemberController(
+        @Qualifier("V2") MemberService memberService,
+        KakaoService kakaoService
+    ) {
         this.memberService = memberService;
+        this.kakaoService = kakaoService;
     }
 
     @PostMapping("/signup")
@@ -73,5 +81,14 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.OK).body(
             memberService.deleteMember(memberDetails.getMember())
         );
+    }
+
+    @GetMapping("/kakao/callback")
+    public ResponseEntity<Void> kakaoLogin(
+        @RequestParam("code") String code,
+        HttpServletResponse response
+    ) {
+        kakaoService.kakaoLogin(code, response);
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 }

--- a/src/main/java/com/sportsecho/member/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/sportsecho/member/dto/KakaoUserInfoDto.java
@@ -1,0 +1,18 @@
+package com.sportsecho.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfoDto {
+    private Long id;
+    private String nickname;
+    private String email;
+
+    public KakaoUserInfoDto(Long id, String nickname, String email) {
+        this.id = id;
+        this.nickname = nickname;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/sportsecho/member/entity/Member.java
+++ b/src/main/java/com/sportsecho/member/entity/Member.java
@@ -44,8 +44,12 @@ public class Member extends TimeStamp {
     @Column(name = "role", nullable = false)
     private MemberRole role;
 
-    @Column(name = "kakao_id")
-    private Long kakaoId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type")
+    private SocialType socialType;
+
+    @Column(name = "social_id")
+    private Long socialId;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> commentList = new ArrayList<>();
@@ -64,8 +68,9 @@ public class Member extends TimeStamp {
         this.role = role;
     }
 
-    public Member updateKakaoId(Long kakaoId) {
-        this.kakaoId = kakaoId;
+    public Member updateSocialIdAndType(Long socialId, SocialType socialType) {
+        this.socialId = socialId;
+        this.socialType = socialType;
         return this;
     }
 

--- a/src/main/java/com/sportsecho/member/entity/Member.java
+++ b/src/main/java/com/sportsecho/member/entity/Member.java
@@ -44,6 +44,9 @@ public class Member extends TimeStamp {
     @Column(name = "role", nullable = false)
     private MemberRole role;
 
+    @Column(name = "kakao_id")
+    private Long kakaoId;
+
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> commentList = new ArrayList<>();
 
@@ -59,6 +62,11 @@ public class Member extends TimeStamp {
         this.email = email;
         this.password = password;
         this.role = role;
+    }
+
+    public Member updateKakaoId(Long kakaoId) {
+        this.kakaoId = kakaoId;
+        return this;
     }
 
     public Member update(String memberName, String password) {

--- a/src/main/java/com/sportsecho/member/entity/SocialType.java
+++ b/src/main/java/com/sportsecho/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.sportsecho.member.entity;
+
+public enum SocialType {
+    KAKAO, NAVER
+}

--- a/src/main/java/com/sportsecho/member/repository/MemberRepository.java
+++ b/src/main/java/com/sportsecho/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.sportsecho.member.repository;
 
 import com.sportsecho.member.entity.Member;
+import com.sportsecho.member.entity.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +11,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
-    Optional<Member> findByKakaoId(Long kakaoId);
+    Optional<Member> findBySocialIdAndSocialType(Long socialId, SocialType socialType);
 }

--- a/src/main/java/com/sportsecho/member/repository/MemberRepository.java
+++ b/src/main/java/com/sportsecho/member/repository/MemberRepository.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByKakaoId(Long kakaoId);
 }

--- a/src/main/java/com/sportsecho/member/service/MemberServiceImplV2.java
+++ b/src/main/java/com/sportsecho/member/service/MemberServiceImplV2.java
@@ -72,7 +72,7 @@ public class MemberServiceImplV2 implements MemberService {
             String refreshToken = jwtUtil.generateRefreshToken();
 
             //ResponseHeader에 토큰 추가
-            setTokenHeader(response, accessToken, refreshToken);
+            jwtUtil.setJwtHeader(response, accessToken, refreshToken);
 
             redisUtil.saveRefreshToken(refreshToken, member.getEmail());
 
@@ -111,7 +111,7 @@ public class MemberServiceImplV2 implements MemberService {
             //accessToken 발급
             String accessToken = jwtUtil.generateAccessToken(member.getEmail(), member.getRole());
 
-            setTokenHeader(response, accessToken, refreshToken);
+            jwtUtil.setJwtHeader(response, accessToken, refreshToken);
         } else {
             throw new GlobalException(JwtErrorCode.REFRESH_TOKEN_NOT_FOUND);
         }
@@ -122,10 +122,5 @@ public class MemberServiceImplV2 implements MemberService {
     public MemberResponseDto deleteMember(Member member) {
         memberRepository.delete(member);
         return MemberMapper.MAPPER.toResponseDto(member);
-    }
-
-    private void setTokenHeader(HttpServletResponse response, String accessToken, String refreshToken) {
-        response.setHeader(JwtUtil.AUTHORIZATION_HEADER, accessToken);
-        response.setHeader(JwtUtil.REFRESH_AUTHORIZATION_HEADER, refreshToken);
     }
 }

--- a/src/main/java/com/sportsecho/member/service/oauth/KakaoService.java
+++ b/src/main/java/com/sportsecho/member/service/oauth/KakaoService.java
@@ -1,0 +1,165 @@
+package com.sportsecho.member.service.oauth;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sportsecho.common.jwt.JwtUtil;
+import com.sportsecho.global.exception.GlobalException;
+import com.sportsecho.member.dto.KakaoUserInfoDto;
+import com.sportsecho.member.entity.Member;
+import com.sportsecho.member.entity.MemberRole;
+import com.sportsecho.member.exception.MemberErrorCode;
+import com.sportsecho.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Slf4j(topic = "KakaoService")
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Value("${kakao.api.key}")
+    private String kakaoApiKey;
+
+    private final PasswordEncoder passwordEncoder;
+    private final RestTemplate restTemplate;
+    private final MemberRepository memberRepository;
+    private final JwtUtil jwtUtil;
+
+    public void kakaoLogin(String code, HttpServletResponse response) {
+        try {
+            // 1. "인가 코드"로 "엑세스 토큰" 요청
+            String accessToken = getToken(code);
+
+            // 2. 토큰으로 카카오 API 호출 : "액세스 토큰"으로 "카카오 사용자 정보" 가져오기
+            KakaoUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
+
+            // 3. 필요시에 회원가입 -> 미가입된 사용자라면 회원가입 후 로그인 처리 후 JWT발급
+            Member kakaoMember = registerKakaoMemberIfNeeded(kakaoUserInfo);
+
+            // 4. JWT 토큰 반환
+            String aToken = jwtUtil.generateAccessToken(kakaoMember.getEmail(), kakaoMember.getRole());
+            String rToken = jwtUtil.generateRefreshToken();
+            jwtUtil.setJwtHeader(response, aToken, rToken);
+        } catch(JsonProcessingException e) {
+            throw new GlobalException(MemberErrorCode.DUPLICATED_EMAIL);
+        }
+    }
+
+    private String getToken(String code) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+            .fromUriString("https://kauth.kakao.com")
+            .path("/oauth/token")
+            .encode()
+            .build()
+            .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HTTP Body 생성
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoApiKey);
+        body.add("redirect_uri", "http://localhost:8080/api/members/kakao/callback");
+        body.add("code", code);
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+            .post(uri)
+            .headers(headers)
+            .body(body);
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+            requestEntity,
+            String.class
+        );
+
+        // HTTP 응답 (JSON) -> 액세스 토큰 파싱
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        return jsonNode.get("access_token").asText();
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfo(String accessToken) throws JsonProcessingException {
+        // 요청 URL 만들기
+        URI uri = UriComponentsBuilder
+            .fromUriString("https://kapi.kakao.com")
+            .path("/v2/user/me")
+            .encode()
+            .build()
+            .toUri();
+
+        // HTTP Header 생성
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity = RequestEntity
+            .post(uri)
+            .headers(headers)
+            .body(new LinkedMultiValueMap<>());
+
+        // HTTP 요청 보내기
+        ResponseEntity<String> response = restTemplate.exchange(
+            requestEntity,
+            String.class
+        );
+
+        JsonNode jsonNode = new ObjectMapper().readTree(response.getBody());
+        Long id = jsonNode.get("id").asLong();
+        String nickname = jsonNode.get("properties")
+            .get("nickname").asText();
+        String email = jsonNode.get("kakao_account")
+            .get("email").asText();
+
+        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
+        return new KakaoUserInfoDto(id, nickname, email);
+    }
+
+    private Member registerKakaoMemberIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
+        Long kakaoId = kakaoUserInfo.getId();
+        Member kakaoMember = memberRepository.findByKakaoId(kakaoId).orElse(null);
+
+        if (kakaoMember == null) {
+            // 카카오 사용자 email과 동일한 email 가진 회원이 있는지 확인
+            String kakaoEmail = kakaoUserInfo.getEmail();
+            Member sameEmailMember = memberRepository.findByEmail(kakaoEmail).orElse(null);
+
+            if (sameEmailMember != null) {
+                kakaoMember = sameEmailMember;
+            } else {
+                // email: kakao email & password: random UUID
+                String email = kakaoUserInfo.getEmail();
+                String encodedPassword = passwordEncoder.encode(UUID.randomUUID().toString());
+
+                kakaoMember = Member.builder()
+                    .memberName(kakaoUserInfo.getNickname())
+                    .email(email)
+                    .password(encodedPassword)
+                    .role(MemberRole.CUSTOMER)
+                    .build();
+            }
+
+            //KakaoId update 및 저장
+            kakaoMember = kakaoMember.updateKakaoId(kakaoId);
+            memberRepository.save(kakaoMember);
+        }
+
+        return kakaoMember;
+    }
+}

--- a/src/main/java/com/sportsecho/member/service/oauth/KakaoService.java
+++ b/src/main/java/com/sportsecho/member/service/oauth/KakaoService.java
@@ -8,6 +8,7 @@ import com.sportsecho.global.exception.GlobalException;
 import com.sportsecho.member.dto.KakaoUserInfoDto;
 import com.sportsecho.member.entity.Member;
 import com.sportsecho.member.entity.MemberRole;
+import com.sportsecho.member.entity.SocialType;
 import com.sportsecho.member.exception.MemberErrorCode;
 import com.sportsecho.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletResponse;
@@ -127,13 +128,12 @@ public class KakaoService {
         String email = jsonNode.get("kakao_account")
             .get("email").asText();
 
-        log.info("카카오 사용자 정보: " + id + ", " + nickname + ", " + email);
         return new KakaoUserInfoDto(id, nickname, email);
     }
 
     private Member registerKakaoMemberIfNeeded(KakaoUserInfoDto kakaoUserInfo) {
         Long kakaoId = kakaoUserInfo.getId();
-        Member kakaoMember = memberRepository.findByKakaoId(kakaoId).orElse(null);
+        Member kakaoMember = memberRepository.findBySocialIdAndSocialType(kakaoId, SocialType.KAKAO).orElse(null);
 
         if (kakaoMember == null) {
             // 카카오 사용자 email과 동일한 email 가진 회원이 있는지 확인
@@ -156,7 +156,7 @@ public class KakaoService {
             }
 
             //KakaoId update 및 저장
-            kakaoMember = kakaoMember.updateKakaoId(kakaoId);
+            kakaoMember = kakaoMember.updateSocialIdAndType(kakaoId, SocialType.KAKAO);
             memberRepository.save(kakaoMember);
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,3 +52,8 @@ cloud:
       auto: false
     s3:
       bucket: sports-echo
+
+
+kakao:
+  api:
+    key: ${kakao-api-key}


### PR DESCRIPTION
## 개요
Member 도메인 카카오 로그인 기능 추가

## 작업사항
- application.yml에 kakao 로그인을 위한 rest-api-key 속성 추가
- Member Entity kakaoId 필드 추가
- KakaoService 및 관련 Dto 추가

## 변경로직
- MemberService에 있던 setJwtHeader() 메서드 JwtUtil로 이동

## 관련이슈
issues #27 