### PR TITLE
Feature/hotdeal

### DIFF
--- a/src/main/java/com/sportsecho/SportsEchoApplication.java
+++ b/src/main/java/com/sportsecho/SportsEchoApplication.java
@@ -2,8 +2,10 @@ package com.sportsecho;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class SportsEchoApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sportsecho/hotdeal/dto/response/HotdealResponseDto.java
+++ b/src/main/java/com/sportsecho/hotdeal/dto/response/HotdealResponseDto.java
@@ -2,9 +2,11 @@ package com.sportsecho.hotdeal.dto.response;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class HotdealResponseDto {
 
@@ -13,6 +15,7 @@ public class HotdealResponseDto {
     private String imageUrl;
     private int price;
     private int sale;
+    private int dealQuantity;
     private LocalDateTime startDay;
     private LocalDateTime dueDay;
 

--- a/src/main/java/com/sportsecho/hotdeal/entity/Hotdeal.java
+++ b/src/main/java/com/sportsecho/hotdeal/entity/Hotdeal.java
@@ -2,6 +2,7 @@ package com.sportsecho.hotdeal.entity;
 
 import com.sportsecho.product.entity.Product;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Hotdeal {
 
     @Id
@@ -59,9 +60,10 @@ public class Hotdeal {
         this.dealQuantity = dealQuantity;
     }
 
-    public void updateHotdealInfo(LocalDateTime startDay, LocalDateTime dueDay, int sale) {
+    public void updateHotdealInfo(LocalDateTime startDay, LocalDateTime dueDay, int sale, int dealQuantity) {
         this.startDay = startDay;
         this.dueDay = dueDay;
         this.sale = sale;
+        this.dealQuantity = dealQuantity;
     }
 }

--- a/src/main/java/com/sportsecho/hotdeal/repository/HotdealRepository.java
+++ b/src/main/java/com/sportsecho/hotdeal/repository/HotdealRepository.java
@@ -1,6 +1,8 @@
 package com.sportsecho.hotdeal.repository;
 
 import com.sportsecho.hotdeal.entity.Hotdeal;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,5 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface HotdealRepository extends JpaRepository<Hotdeal, Long> {
 
     Page<Hotdeal> findAll(Pageable pageable);
+
+    List<Hotdeal> findAllByDueDayBefore(LocalDateTime now);
+
+    List<Hotdeal> findAllByDealQuantity(int dealQuantity);
 
 }

--- a/src/main/java/com/sportsecho/hotdeal/scheduler/HotdealScheduler.java
+++ b/src/main/java/com/sportsecho/hotdeal/scheduler/HotdealScheduler.java
@@ -1,0 +1,54 @@
+package com.sportsecho.hotdeal.scheduler;
+
+import com.sportsecho.hotdeal.entity.Hotdeal;
+import com.sportsecho.hotdeal.repository.HotdealRepository;
+import com.sportsecho.product.entity.Product;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotdealScheduler {
+
+    private final HotdealRepository hotdealRepository;
+
+    // 매분마다 시행
+    @Scheduled(cron = "0 * * * * *")
+    @Transactional
+    public void deleteClosedHotdeal() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Hotdeal> expiredHotdeals = hotdealRepository.findAllByDueDayBefore(now);
+        expiredHotdeals.stream()
+            .map(Hotdeal::getProduct)
+            .filter(Objects::nonNull)
+            .forEach(Product::unlinkHotdeal); // deleteAll 메소드 호출 전에 Product 엔티티와의 관계를 끊기
+
+        if (!expiredHotdeals.isEmpty()) {
+            log.info("마감시간이 지난 HOTDEAL {}개를 삭제하겠습니다.", expiredHotdeals.size());
+            hotdealRepository.deleteAll(expiredHotdeals);
+            hotdealRepository.flush();
+            List<Hotdeal> expiredHotdealsForCheck = hotdealRepository.findAllByDueDayBefore(now);
+            log.info(String.valueOf(expiredHotdealsForCheck.size()));
+        }
+
+        List<Hotdeal> hotdealsWithZeroQuantity = hotdealRepository.findAllByDealQuantity(0);
+        hotdealsWithZeroQuantity.stream()
+            .map(Hotdeal::getProduct)
+            .filter(Objects::nonNull)
+            .forEach(Product::unlinkHotdeal);
+
+        if (!hotdealsWithZeroQuantity.isEmpty()) {
+            log.info("한정수령이 모두 판매된 Hotdeal {}개를 삭제하겠습니다.", hotdealsWithZeroQuantity.size());
+            hotdealRepository.deleteAll(hotdealsWithZeroQuantity);
+            hotdealRepository.flush();
+        }
+    }
+
+}

--- a/src/main/java/com/sportsecho/hotdeal/service/HotdealService.java
+++ b/src/main/java/com/sportsecho/hotdeal/service/HotdealService.java
@@ -18,4 +18,6 @@ public interface HotdealService {
     HotdealResponseDto updateHotdeal(Member member, Long hotdealId, UpdateHotdealInfoRequestDto requestDto);
 
     void decreaseHotdealDealQuantity(Member member, Long hotdealId ,int quantity);
+
+    void deleteHotdeal(Member member, Long hotdealId);
 }

--- a/src/main/java/com/sportsecho/hotdeal/service/HotdealServiceImplV1.java
+++ b/src/main/java/com/sportsecho/hotdeal/service/HotdealServiceImplV1.java
@@ -38,7 +38,7 @@ public class HotdealServiceImplV1 implements HotdealService {
     @Transactional
     public HotdealResponseDto createHotdeal(Member member, Long productId,
         HotdealRequestDto requestDto) {
-        if (isAuthorized(member)) {
+        if (!isAuthorized(member)) {
             throw new GlobalException(HotdealErrorCode.NO_AUTHORIZATION);
         }
 
@@ -70,14 +70,13 @@ public class HotdealServiceImplV1 implements HotdealService {
     @Transactional
     public HotdealResponseDto updateHotdeal(Member member, Long hotdealId,
         UpdateHotdealInfoRequestDto requestDto) {
-        if (isAuthorized(member)) {
+        if (!isAuthorized(member)) {
             throw new GlobalException(HotdealErrorCode.NO_AUTHORIZATION);
         }
         Hotdeal hotdeal = findHotdeal(hotdealId);
 
         hotdeal.updateHotdealInfo(requestDto.getStartDay(), requestDto.getDueDay(),
-            requestDto.getSale());
-//        hotdealRepository.save(hotdeal); 더티 체킹 X
+            requestDto.getSale(), requestDto.getDealQuantity());
 
         return HotdealMapper.INSTANCE.toResponseDto(hotdeal);
     }
@@ -85,7 +84,7 @@ public class HotdealServiceImplV1 implements HotdealService {
     @Override
     @Transactional
     public void decreaseHotdealDealQuantity(Member member, Long hotdealId ,int quantity) {
-        if (isAuthorized(member)) {
+        if (!isAuthorized(member)) {
             throw new GlobalException(HotdealErrorCode.NO_AUTHORIZATION);
         }
         Hotdeal hotdeal = findHotdeal(hotdealId);
@@ -95,6 +94,17 @@ public class HotdealServiceImplV1 implements HotdealService {
         }
 
         hotdeal.updateDealQuantity(hotdeal.getDealQuantity() - quantity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteHotdeal(Member member, Long hotdealId) {
+        if (!isAuthorized(member)) {
+            throw new GlobalException(HotdealErrorCode.NO_AUTHORIZATION);
+        }
+        Hotdeal hotdeal = findHotdeal(hotdealId);
+
+        hotdealRepository.delete(hotdeal);
     }
 
     private Product findProduct(Long productId) {

--- a/src/main/java/com/sportsecho/product/entity/Product.java
+++ b/src/main/java/com/sportsecho/product/entity/Product.java
@@ -55,6 +55,10 @@ public class Product extends TimeStamp {
         return this;
     }
 
+    public void unlinkHotdeal() {
+        this.hotdeal = null;
+    }
+
     public void updateProductImageUrl(String imageUrl) {
         this.imageUrl = imageUrl;
     }


### PR DESCRIPTION
## 개요
마감 핫딜 삭제 Scheduler

## 작업사항
dueDay가 동작 시간 LocalDate기준보다 이전일때 삭제
dealQuantity가 동작 시점에 0일때 삭제

## 변경로직
기본 delete API도 추가
Mapper 이슈로 도메인, dto 어노테이션 추가

## 관련이슈
영속성 flush를 날려줘도 dataIntegriry때문인지 (런타임에서도 에러 발생하지 않았음) delete쿼리를 날리지 않고 실제로 반영되지 않았음.
unlikedHotdeal() 메서드를 Product에 추가하여 직접 연관관계를 끊어주었고 다시 핫딜 추가 했을 때 연관관계 매핑까지 잘되고 있음